### PR TITLE
Change directory/module structure; change log format

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,7 +1,7 @@
 from datetime import date
 from logging import Logger
 
-from config.params import config, DEBUG
+from params import config, DEBUG
 from settings import LEVELS, LOG_DIR
 
 # Create 'logs' directory if necessary

--- a/params.py
+++ b/params.py
@@ -1,7 +1,10 @@
-# Set DEBUG True for for developers/maintainers
+from settings import LOGGER_NAME
+
+# Set DEBUG True for developers/maintainers
 DEBUG = False
 
-FORMAT = '%(asctime)s - %(lineno)d - %(levelname)s - %(module)s - %(message)s'
+FORMAT = ('%(asctime)s - %(levelname)s - %(module)s - %(funcName)s - '
+          '%(lineno)d - %(message)s')
 if DEBUG:
     LEVEL = 'DEBUG'
 else:
@@ -32,7 +35,7 @@ config = {
         }
     },
     'loggers': {
-        '': {
+        LOGGER_NAME: {
             'handlers': ['streamHandler', 'fileHandler'],
             'level': LEVEL,
         }

--- a/params.py
+++ b/params.py
@@ -1,8 +1,7 @@
-from settings import LOGGER_NAME
-
 # Set DEBUG True for developers/maintainers
 DEBUG = False
 
+LOGGER_NAME = 'sampleLogger'
 FORMAT = ('%(asctime)s - %(levelname)s - %(module)s - %(funcName)s - '
           '%(lineno)d - %(message)s')
 if DEBUG:

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+from params import LOGGER_NAME
+
 PWD = Path.cwd()
 LOG_DIR = PWD.joinpath('logs')
 CONFIG_DIR = PWD.joinpath('config')
@@ -9,7 +11,5 @@ LEVELS = {
     0: logging.NOTSET, 1: logging.DEBUG, 2: logging.INFO,
     3: logging.WARNING, 4: logging.ERROR, 5: logging.CRITICAL
 }
-
-LOGGER_NAME = 'sampleLogger'
 
 TYPE_ERROR_MESSAGE = "both args must be integers"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,4 +1,4 @@
-from ..config.params import DEBUG
+from ..params import DEBUG
 
 
 def test_debug() -> None:


### PR DESCRIPTION
- Change `config/params.py` to `params.py` for simplicity
- Change the log format to get information about the module and function name